### PR TITLE
Modernize UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,6 @@
       installBtn.disabled = true;
       deferredPrompt.prompt();
       const choice = await deferredPrompt.userChoice;
-      console.log('PWA install choice:', choice.outcome);
       deferredPrompt = null;
       installBtn.style.display = 'none'
     });
@@ -203,10 +202,8 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 });
 document.querySelectorAll('.button').forEach(btn => {
-  console.log('attaching ripple listener to', btn);
-  
+
   btn.addEventListener('click', function(e) {
-    console.log('ripple click on', this);
     
     const ripple = document.createElement('span');
     ripple.classList.add('ripple');

--- a/index.html
+++ b/index.html
@@ -28,14 +28,16 @@
   </div>
   <main>
     <div id="home-page" class="page active">
-      <button class="button" onclick="showPage('picked-up-page')">I Picked Up Narcan</button>
-      <button class="button" onclick="showPage('report-use-page')">Report Narcan Use</button>
-      <button class="link-button" onClick="showPage('volunteer-page')">Volunteer with ECLC!</button>
-      <button class="link-button" onclick="showPage('contact-page')">Contact ECLC</button>
-      <button class="link-button" onclick="showPage('resources-page')">Community Resources</button>
-      <button class="link-button" onclick="showPage('impact-page')">Community Impact</button>
-      <button class="link-button" onclick="showPage('devotional-page')">Recovery Devotional</button>
-      <button class="button" id="install-btn" style="display:none">Connect and Support with the ECLC App!</button>
+      <div class="home-buttons">
+        <button class="button" onclick="showPage('picked-up-page')">I Picked Up Narcan</button>
+        <button class="button" onclick="showPage('report-use-page')">Report Narcan Use</button>
+        <button class="link-button" onClick="showPage('volunteer-page')">Volunteer with ECLC!</button>
+        <button class="link-button" onclick="showPage('contact-page')">Contact ECLC</button>
+        <button class="link-button" onclick="showPage('resources-page')">Community Resources</button>
+        <button class="link-button" onclick="showPage('impact-page')">Community Impact</button>
+        <button class="link-button" onclick="showPage('devotional-page')">Recovery Devotional</button>
+        <button class="button" id="install-btn" style="display:none">Connect and Support with the ECLC App!</button>
+      </div>
     </div>
     <div id="picked-up-page" class="page">
       <div class="form-container" id="pickup-container">
@@ -224,6 +226,7 @@
       </div>
     </div>
     <div id="contact-page" class="page">
+      <div class="form-container">
       <h2>Contact ECLC</h2>
       <div class="map-container">
         <iframe
@@ -246,8 +249,10 @@
       <p><a href="tel:+18506125640" class="link-button">Call Us</a></p>
       <p><a href="mailto:emeraldcoastlifecenter@gmail.com" class="link-button">Email Us</a></p>
       <div class="back-button" onclick="showPage('home-page')">⬅️ Back to Home</div>
+      </div>
     </div>
     <div id="resources-page" class="page">
+      <div class="form-container">
       <h2>Community Resources</h2>
       <ul class="resources">
         <li><a href="https://emeraldcoastlifecenter.org" target="_blank">Lighthouse @ Emerald Coast Life Center</a></li>
@@ -256,8 +261,10 @@
         <li><a href="https://988lifeline.org" target="_blank">24/7 Crisis Hotline</a></li>
       </ul>
       <div class="back-button" onclick="showPage('home-page')">⬅️ Back to Home</div>
+      </div>
     </div>
     <div id="impact-page" class="page">
+      <div class="form-container">
       <h2>Community Impact</h2>
       <label for="impact-range">Select Range:</label><br>
       <select id="impact-range" onchange="updateImpact()">
@@ -267,8 +274,10 @@
       </select>
       <div id="impact-stats"></div>
       <div class="back-button" onclick="showPage('home-page')">⬅️ Back to Home</div>
+      </div>
     </div>
     <div id="devotional-page" class="page">
+      <div class="form-container">
       <h2>Recovery Devotional</h2>
       <div class="dev-nav">
         <button id="prev-day" aria-label="Previous Devotional">←</button>
@@ -279,6 +288,7 @@
       <div id="devotional-text">Loading devotional...</div>
       <button id="share-devotional" class="button" style="max-width:200px;margin-top:1rem;">Share</button>
       <div class="back-button" onclick="showPage('home-page')">⬅️ Back to Home</div>
+      </div>
     </div>
   </main>
   <footer>Connect and Support!</footer>

--- a/styles.css
+++ b/styles.css
@@ -45,6 +45,7 @@
       background-size: auto;
       font-family: 'Inter Variable', sans-serif;
       font-optical-sizing: auto;
+      scroll-behavior: smooth;
     }
     body {
       margin: 0;
@@ -78,9 +79,17 @@
     .header {
       display: flex;
       align-items: center;
+      justify-content: space-between;
       padding: 16px;
       flex-shrink: 0;
-      background: transparent;
+      background: rgba(255, 255, 255, 0.4);
+      backdrop-filter: blur(6px);
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+      border-bottom-left-radius: 16px;
+      border-bottom-right-radius: 16px;
+      position: sticky;
+      top: 0;
+      z-index: 1000;
     }
     .header-left {
       flex: 1;
@@ -105,8 +114,15 @@
       text-align: center;
       padding: 20px;
     }
+    .home-buttons {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      max-width: 480px;
+      margin: auto;
+    }
     .button {
-      background-color: var(--mint-green);
+      background: linear-gradient(135deg, var(--mint-green), var(--teal));
       color: white;
       padding: 14px 28px;
       margin: 12px 12px 32px;
@@ -115,7 +131,7 @@
       font-size: 20px;
       box-shadow: 0 4px 6px rgba(0,0,0,0.1);
       cursor: pointer;
-      transition: background-color 0.3s;
+      transition: background 0.3s, transform 0.2s;
       max-width: 300px;
       width: 100%;
       display: inline-flex;
@@ -125,7 +141,8 @@
       overflow: hidden;
     }
     .button:hover {
-      background-color: var(--teal);
+      background: linear-gradient(135deg, var(--teal), var(--mint-green));
+      transform: translateY(-2px);
     }
     .button:focus {
       outline: 3px solid var(--text-dark);
@@ -158,10 +175,14 @@
       padding: 0;
       color: var(--text-dark);
       font-size: 18px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
       cursor: pointer;
       text-decoration: none;
+      transition: color 0.3s;
     }
     .link-button:hover {
+      color: var(--teal);
       text-decoration: underline;
     }
     .page {
@@ -182,6 +203,11 @@
       font-size: 16px;
       color: var(--text-dark);
       cursor: pointer;
+      font-weight: 600;
+      text-decoration: underline;
+    }
+    .back-button:hover {
+      color: var(--teal);
     }
     footer {
       flex-shrink: 0;
@@ -193,6 +219,19 @@
     #impact-range {
       margin-bottom: 16px;
       font-size: 16px;
+    }
+    #impact-stats {
+      margin-top: 1rem;
+      font-size: 1.125rem;
+      line-height: 1.4;
+      background: rgba(255, 255, 255, 0.3);
+      backdrop-filter: blur(6px);
+      padding: 1rem;
+      border-radius: 8px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+      max-width: 320px;
+      margin-left: auto;
+      margin-right: auto;
     }
     ul.resources {
       list-style: none;
@@ -224,6 +263,27 @@
   font-weight: bold;
   font-size: 1.25rem;
   margin: 0.5em 0;
+}
+.dev-nav {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.dev-nav button {
+  background: none;
+  border: 2px solid var(--mint-green);
+  color: var(--text-dark);
+  padding: 0.25rem 0.75rem;
+  border-radius: 6px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+.dev-nav button:hover {
+  background: var(--mint-green);
+  color: white;
 }
 .map-container {
   max-width: 360px;
@@ -265,9 +325,9 @@
   width: 90%;
   margin: 2rem auto;
   padding: 2rem;
-  background: rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(8px);
-  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(10px);
+  border-radius: 16px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
   opacity: 0;
   transform: translateY(20px);


### PR DESCRIPTION
## Summary
- wrap non-form pages in `.form-container` for consistent glass cards
- adjust home page with a `.home-buttons` container
- improve header with sticky blurred style
- upgrade buttons and links with gradients and transitions
- style the devotional navigation and impact stats
- clean up console logging

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68407dc93c4083269837fba6f588b774