### PR TITLE
Adjust pickup calculation in doGet

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -137,7 +137,8 @@ const livesSaved = useF.filter(r => r[2]==='Overdose Reversal').length;
 const hospitalized = useF.filter(r => r[4]==='Yes').length;
 
 const result = {
-  pickedUp: dosesPickedUp,
+  pickedUp: totalBoxes,
+  dosesPickedUp: dosesPickedUp,
   dosesUsed: totalUsed,
   livesSaved: livesSaved,
   hospitalizations: hospitalized


### PR DESCRIPTION
## Summary
- calculate `pickedUp` using `totalBoxes` not `dosesPickedUp`
- expose doubled value as new `dosesPickedUp` property

## Testing
- `npm test` *(fails: missing `package.json`)*
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684082f3f2fc83268d9b019ceb56285d